### PR TITLE
Add Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,85 @@
+trigger:
+- develop
+
+variables:
+  COVERALLS_GIT_BRANCH: '$(Build.SourceBranchName)'
+  COVERALLS_GIT_COMMIT: '$(Build.SourceVersion)'
+  COVERALLS_SERVICE_JOB_ID: '$(Build.BuildId)'
+  COVERALLS_SERVICE_NAME: 'Azure Pipelines'
+  CI_PULL_REQUEST: '$(System.PullRequest.PullRequestNumber)'
+
+jobs:
+- job: Linux 
+  strategy:
+    matrix:
+      Node 4:
+        NODE_VERSION: '4.x'
+      Node 5:
+        NODE_VERSION: '5.x'
+      Node 6:
+        NODE_VERSION: '6.x'
+      Node 7:
+        NODE_VERSION: '7.x'
+      Node 8:
+        NODE_VERSION: '8.x'
+      Node 12:
+        NODE_VERSION: '12.x'
+        COVERAGE: 'true'
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '$(NODE_VERSION)'
+    displayName: 'Install Node $(NODE_VERSION)'
+
+  - script: |
+      if [[ `npm -v` == 2* ]]; then npm i -g npm@3; fi
+      npm install
+      npm install -g grunt-cli
+    displayName: 'npm install'
+
+  - script: grunt
+    displayName: 'grunt'
+
+  - script: npm run coveralls
+    env:
+      COVERALLS_REPO_TOKEN: $(COVERALLS_REPO_TOKEN)
+    condition: and(succeeded(), eq(variables['COVERAGE'], 'true'))
+    displayName: 'Code coverage'
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(Build.SourcesDirectory)/coverage/cobertura-coverage.xml'
+    condition: and(succeeded(), eq(variables['COVERAGE'], 'true'))
+    displayName: 'Publish code coverage'
+
+- job: Windows 
+  strategy:
+    matrix:
+      Node 6:
+        NODE_VERSION: '6.x'
+      Node 7:
+        NODE_VERSION: '7.x'
+      Node 8:
+        NODE_VERSION: '8.x'
+      Node 12:
+        NODE_VERSION: '12.x'
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '$(NODE_VERSION)'
+    displayName: 'Install Node $(NODE_VERSION)'
+
+  - script: |
+      npm install
+      npm install -g grunt-cli
+    displayName: 'npm install'
+
+  - script: grunt
+    displayName: 'grunt'

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "typescript-test": "tsc --project typing-tests",
         "test": "grunt test",
         "coverage": "nyc npm test && nyc report",
-        "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
+        "coveralls": "nyc npm test && nyc report --reporter=text-lcov --reporter=cobertura | coveralls"
     },
     "spm": {
         "main": "moment.js",


### PR DESCRIPTION
Hi! I'm part of the Azure DevOps team at Microsoft. Wondering if there's any interest in trying out Azure Pipelines. If so I've already done most of the work for you. Some reasons you might be interested:

- Generous free allowance for open source projects - 10 jobs in parallel, unlimited build minutes
- All 3 major platforms supported - Linux, Windows, macOS - hosted by us in Azure
- Great build/test analytics, giving you insights into trends over time

You can preview the results in the [demo pipeline I setup](https://dev.azure.com/dylansmith/Moment/_build?definitionId=35).

Here's some more details on what I've done here:

1. Recreated what the Travis build does today - builds against 6 versions of Node on Linux and publishes to coveralls
2. Added 4 more jobs to build against some Node versions on Windows (it's easy to add more, I deliberately kept it to 10 jobs for perf reasons)
3. Tweaked some things so it only does code coverage on one out of the 10 jobs (for a bit of perf)
4. Publish the code coverage to Azure Pipelines (in addition to coveralls) - because why not?!
5. The whole thing runs in about 3 mins (vs 8-10 for the recent Travis builds)

![image](https://user-images.githubusercontent.com/1508559/57563568-f3758580-7364-11e9-8cd1-be012087aeb9.png)

![image](https://user-images.githubusercontent.com/1508559/57563734-ccb84e80-7366-11e9-8827-e80341004ba7.png)

